### PR TITLE
Modified body's overflow attribute to fix html file downloads

### DIFF
--- a/extension/src/Printer/Printer.ts
+++ b/extension/src/Printer/Printer.ts
@@ -335,7 +335,7 @@ export class Printer {
                         ${head}
                         <style>
                         body {
-                            overflow: hidden;
+                            overflow: auto;
                             background: url(https://www.dndbeyond.com/attachments/0/84/background_texture.png) #f9f9f9 !important;
                         }
                             .print-hidden {


### PR DESCRIPTION
The overflow attribute on the downloaded html's body was preventing scrolling of the downloaded page.

This affects the printed version also, however I have not noticed any affect to PDF mode.